### PR TITLE
feat: support .vue files coverage

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -2,7 +2,8 @@
 // https://on.cypress.io/intelligent-code-completion
 /// <reference types="Cypress" />
 
-import {add} from '../unit'
+import { add } from '../unit'
+const { fixSourcePathes } = require('../../utils')
 
 context('Page test', () => {
   beforeEach(() => {
@@ -27,5 +28,34 @@ context('Unit tests', () => {
 
   it('concatenates strings', () => {
     expect(add('foo', 'Bar')).to.equal('fooBar')
+  })
+
+  it('fixes webpack loader source-map path', () => {
+    const coverage = {
+      '/folder/module.js': {
+        inputSourceMap: {
+          sources: ['/folder/module.js']
+        }
+      },
+      '/folder/component.vue': {
+        inputSourceMap: {
+          sources: [
+            '/folder/node_modules/cache-loader/dist/cjs.js??ref--0-0!/folder/node_modules/vue-loader/lib/index.js??vue-loader-options!/folder/component.vue?vue&type=script&lang=ts&'
+          ]
+        }
+      },
+      '/folder/module-without-sourcemap.js': {
+        path: '/folder/module-without-sourcemap.js'
+      }
+    }
+
+    fixSourcePathes(coverage)
+
+    expect(coverage['/folder/module.js'].inputSourceMap.sources)
+      .to.deep.equal(['/folder/module.js'])
+    expect(coverage['/folder/component.vue'].inputSourceMap.sources)
+      .to.deep.equal(['/folder/component.vue'])
+    expect(coverage['/folder/module-without-sourcemap.js'].path)
+      .to.eq('/folder/module-without-sourcemap.js')
   })
 })

--- a/task.js
+++ b/task.js
@@ -22,6 +22,7 @@ function saveCoverage (coverage) {
 function fixSourcePathes (coverage) {
   Object.keys(coverage).forEach(file => {
     const sourcemap = coverage[file].inputSourceMap
+    if (!sourcemap) return
     sourcemap.sources = sourcemap.sources.map(source => {
       let cleaned = source
       if (cleaned.includes('!')) cleaned = cleaned.split('!').pop()

--- a/task.js
+++ b/task.js
@@ -18,6 +18,19 @@ function saveCoverage (coverage) {
   writeFileSync(nycFilename, JSON.stringify(coverage, null, 2))
 }
 
+// Remove potential Webpack loaders string and query parameters from sourcemap path
+function fixSourcePathes (coverage) {
+  Object.keys(coverage).forEach(file => {
+    const sourcemap = coverage[file].inputSourceMap
+    sourcemap.sources = sourcemap.sources.map(source => {
+      let cleaned = source
+      if (cleaned.includes('!')) cleaned = cleaned.split('!').pop()
+      if (cleaned.includes('?')) cleaned = cleaned.split('?').shift()
+      return cleaned
+    })
+  })
+}
+
 module.exports = {
   /**
    * Clears accumulated code coverage information.
@@ -49,6 +62,7 @@ module.exports = {
    * with previously collected coverage.
    */
   combineCoverage (coverage) {
+    fixSourcePathes(coverage)
     const previous = existsSync(nycFilename)
       ? JSON.parse(readFileSync(nycFilename))
       : istanbul.createCoverageMap({})

--- a/task.js
+++ b/task.js
@@ -3,6 +3,7 @@ const { join } = require('path')
 const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs')
 const execa = require('execa')
 const debug = require('debug')('code-coverage')
+const { fixSourcePathes } = require('./utils')
 
 // these are standard folder and file names used by NYC tools
 const outputFolder = '.nyc_output'
@@ -16,20 +17,6 @@ function saveCoverage (coverage) {
   }
 
   writeFileSync(nycFilename, JSON.stringify(coverage, null, 2))
-}
-
-// Remove potential Webpack loaders string and query parameters from sourcemap path
-function fixSourcePathes (coverage) {
-  Object.keys(coverage).forEach(file => {
-    const sourcemap = coverage[file].inputSourceMap
-    if (!sourcemap) return
-    sourcemap.sources = sourcemap.sources.map(source => {
-      let cleaned = source
-      if (cleaned.includes('!')) cleaned = cleaned.split('!').pop()
-      if (cleaned.includes('?')) cleaned = cleaned.split('?').shift()
-      return cleaned
-    })
-  })
 }
 
 module.exports = {

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,17 @@
+module.exports = {
+  /**
+   * Remove potential Webpack loaders string and query parameters from sourcemap path
+   */
+  fixSourcePathes (coverage) {
+    Object.keys(coverage).forEach(file => {
+      const sourcemap = coverage[file].inputSourceMap
+      if (!sourcemap) return
+      sourcemap.sources = sourcemap.sources.map(source => {
+        let cleaned = source
+        if (cleaned.includes('!')) cleaned = cleaned.split('!').pop()
+        if (cleaned.includes('?')) cleaned = cleaned.split('?').shift()
+        return cleaned
+      })
+    })
+  }
+}


### PR DESCRIPTION
Hi. I managed to make .vue files coverage appear in report.

The issue is the sourcemap resource path for .vue file is a crappy Webpack loaders string from vue-loader, like "cache-loader!vue-loader!file.vue?type=script,lang=ts&". 
So it's needed to clean up that path before storing the coverage report.

I've been inspired by an option on karma-coverage-istanbul-reporter doing exactly this.