### PR TITLE
fix: update nyc reporter to lcov

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ module.exports = (on, config) => {
 }
 ```
 
-If your application is loaded Istanbul-instrumented source code, then the coverage information will be automatically saved into `.nyc_output` folder and a report will be generated after the tests finish (even in the interactive mode). Find the HTML report in the `coverage` folder.
+If your application is loaded Istanbul-instrumented source code, then the coverage information will be automatically saved into `.nyc_output` folder and a report will be generated after the tests finish (even in the interactive mode). Find the LCOV and HTML report in the `coverage/lcov-report` folder.
 
 ![Coverage report](images/coverage.jpg)
 

--- a/task.js
+++ b/task.js
@@ -73,7 +73,7 @@ module.exports = {
       return null
     }
     const command = 'nyc'
-    const args = ['report', '--reporter=html']
+    const args = ['report', '--reporter=lcov']
     debug('saving coverage report using command: %s %s', command, args)
     // should we generate report via NYC module API?
     return execa(command, args, { stdio: 'inherit' })


### PR DESCRIPTION
Fixes #33.

Tested locally and generate both HTML and LCOV reports, and it generated both reports to `./coverage/lcov-report`.