### PR TITLE
Move browserify-preprocessor to peer-dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ That should be it!
 
 If you test your application code directly from `specs` you might want to instrument them and combine unit test code coverage with any end-to-end code coverage (from iframe). You can easily instrument spec files using [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) for example.
 
-Install the plugin
+Install the plugin and the preprocessor
 
 ```
-npm i -D babel-plugin-istanbul
+npm i -D babel-plugin-istanbul @cypress/browserify-preprocessor
 ```
 
 Set your `.babelrc` file

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   "peerDependencies": {
     "cypress": "*",
     "nyc": "*",
-    "istanbul-lib-coverage": "*"
+    "istanbul-lib-coverage": "*",
+    "@cypress/browserify-preprocessor": "*"
   },
   "repository": {
     "type": "git",
@@ -43,7 +44,6 @@
   },
   "private": false,
   "dependencies": {
-    "@cypress/browserify-preprocessor": "2.1.1",
     "debug": "4.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Hello.

Do you see any problem moving @cypress/browserify-preprocessor to peer-dependencies ?

Storybook would no longer compile because of a version issue (babel/core, babel/preset-env or something else) caused by browserify-preprocessor's dependencies.