### PR TITLE
feat: add non .babelrc method

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,17 @@ module.exports = (on, config) => {
 
 Now the code coverage from spec files will be combined with end-to-end coverage.
 
+### Alternative
+
+If you cannot use `.babelrc` for some reason (maybe it is used by other tools?), try pushing `babel-plugin-istanbul` directory to browserify plugins list.
+
+```js
+module.exports = (on, config) => {
+  on('task', require('@cypress/code-coverage/task'))
+  on('file:preprocessor', require('@cypress/code-coverage/use-browserify-istanbul'))
+}
+```
+
 ## Instrument backend code
 
 You can also instrument your server-side code and produce combined coverage report that covers both the backend and frontend code.

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -5,4 +5,8 @@ module.exports = (on, config) => {
   // to get the code coverage from unit tests
   // https://glebbahmutov.com/blog/combined-end-to-end-and-unit-test-coverage/
   on('file:preprocessor', require('../../use-babelrc'))
+
+  // or use browserify and just push babel-plugin-istanbul
+  // directory to the list of babelify plugins
+  // on('file:preprocessor', require('../../use-browserify-istanbul'))
 }

--- a/use-browserify-istanbul.js
+++ b/use-browserify-istanbul.js
@@ -1,0 +1,7 @@
+const browserify = require('@cypress/browserify-preprocessor')
+
+const options = browserify.defaultOptions
+// transform[1][1] is "babelify"
+// so we just add our code instrumentation plugin to the list
+options.browserifyOptions.transform[1][1].plugins.push('babel-plugin-istanbul')
+module.exports = browserify(options)


### PR DESCRIPTION
- closes #47

```js
module.exports = (on, config) => {
  on('task', require('@cypress/code-coverage/task'))
  on('file:preprocessor', require('@cypress/code-coverage/use-browserify-istanbul'))
}
```

Avoids using `.babelrc`