### PR TITLE
Save coverage for each page in a test

### DIFF
--- a/cypress/about.html
+++ b/cypress/about.html
@@ -1,0 +1,5 @@
+<body>
+  <h2>About</h2>
+  <main id="content"></main>
+  <script src="about.js"></script>
+</body>

--- a/cypress/about.js
+++ b/cypress/about.js
@@ -1,0 +1,3 @@
+document
+  .getElementById('content')
+  .appendChild(document.createTextNode('Est. 2019'))

--- a/cypress/index.html
+++ b/cypress/index.html
@@ -1,4 +1,7 @@
 <body>
+  <nav>
+    <a href="/about.html">About</a>
+  </nav>
   <h2>Test page</h2>
   <p>Open the DevTools to see console messages</p>
   <script src="app.js"></script>

--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -12,6 +12,8 @@ context('Page test', () => {
         cy.spy(win.console, 'log').as('log')
       }
     })
+
+    cy.contains('About').click()
   })
 
   it('logs names', function () {


### PR DESCRIPTION
Save coverage for each page visited in a test by keeping a reference to the coverage for each app window loaded and then saving the coverage at the end after coverage is calculated.

The implementation in the PR keeps the behavior of saving coverage after each test since that is the current behavior and I believe it would be necessary for #4. However, I think it would also be possible to initialize the array and event listener in `before()` and only save coverage in `after()` if that is desired instead.

Closes #69 