### PR TITLE
feat: print coverage counters in the reporter

### DIFF
--- a/cypress/integration/spec.js
+++ b/cypress/integration/spec.js
@@ -3,7 +3,7 @@
 /// <reference types="Cypress" />
 
 import { add } from '../unit'
-const { fixSourcePathes } = require('../../utils')
+const { fixSourcePaths } = require('../../utils')
 
 context('Page test', () => {
   beforeEach(() => {
@@ -30,7 +30,7 @@ context('Unit tests', () => {
     expect(add('foo', 'Bar')).to.equal('fooBar')
   })
 
-  it('fixes webpack loader source-map pathes', () => {
+  it('fixes webpack loader source-map paths', () => {
     const coverage = {
       '/absolute/src/component.vue': {
         path: '/absolute/src/component.vue',
@@ -47,7 +47,7 @@ context('Unit tests', () => {
       }
     }
 
-    fixSourcePathes(coverage)
+    fixSourcePaths(coverage)
 
     expect(coverage).to.deep.eq({
       '/absolute/src/component.vue': {

--- a/utils.js
+++ b/utils.js
@@ -4,7 +4,7 @@ module.exports = {
    * (coverage report wouldn't work with source-map path being relative
    * or containing Webpack loaders and query parameters)
    */
-  fixSourcePathes(coverage) {
+  fixSourcePaths(coverage) {
     Object.values(coverage).forEach(file => {
       const { path: absolutePath, inputSourceMap } = file
       const fileName = /([^\/\\]+)$/.exec(absolutePath)[1]


### PR DESCRIPTION
To quickly see the coverage after each test

<img width="1281" alt="Screen Shot 2019-09-10 at 10 01 00 AM" src="https://user-images.githubusercontent.com/2212006/64620577-1fa42000-d3b2-11e9-9731-9c8057115c09.png">

I think it looks kind of nice, here is TodoMVC

<img width="1280" alt="Screen Shot 2019-09-10 at 10 08 49 AM" src="https://user-images.githubusercontent.com/2212006/64621060-0b145780-d3b3-11e9-9c69-b436919a9c13.png">
