### PR TITLE
Bypass perfomance issues through sending Strings instead of Objects

### DIFF
--- a/support.js
+++ b/support.js
@@ -15,7 +15,7 @@ afterEach(() => {
     const applicationSourceCoverage = win.__coverage__
 
     if (applicationSourceCoverage) {
-      cy.task('combineCoverage', applicationSourceCoverage)
+      cy.task('combineCoverage', JSON.stringify(applicationSourceCoverage))
     }
   })
 })
@@ -46,7 +46,7 @@ after(() => {
           // original failed request
           return
         }
-        cy.task('combineCoverage', coverage)
+        cy.task('combineCoverage', JSON.stringify(coverage))
       })
   }
 
@@ -67,7 +67,7 @@ after(() => {
       (fileCoverage, filename) =>
         filename.startsWith(specFolder) || filename.startsWith(supportFolder)
     )
-    cy.task('combineCoverage', coverage)
+    cy.task('combineCoverage', JSON.stringify(coverage))
   }
 
   // when all tests finish, lets generate the coverage report

--- a/task.js
+++ b/task.js
@@ -61,7 +61,8 @@ module.exports = {
    * Combines coverage information from single test
    * with previously collected coverage.
    */
-  combineCoverage (coverage) {
+  combineCoverage (coverageString) {
+    const coverage = JSON.parse(coverageString)
     fixSourcePathes(coverage)
     const previous = existsSync(nycFilename)
       ? JSON.parse(readFileSync(nycFilename))


### PR DESCRIPTION
Workaround for https://github.com/cypress-io/code-coverage/issues/26 and https://github.com/cypress-io/code-coverage/issues/76.

Since the circular-json detecion implemented here https://github.com/cypress-io/cypress/pull/4407 the combine coverage slows down or even breaks the tests in big projects. 

By stringify the Json we can bypass the performance issues for most cases. I'm not sure how it behaves when even `JSON.stringfy`slows down but even then it should be better than the circular-json chekcup.