### PR TITLE
fix: stringify coverage object to improve performance

### DIFF
--- a/support.js
+++ b/support.js
@@ -23,7 +23,7 @@ if (Cypress.env('coverage') === false) {
       const applicationSourceCoverage = win.__coverage__
 
       if (applicationSourceCoverage) {
-        cy.task('combineCoverage', applicationSourceCoverage)
+        cy.task('combineCoverage', JSON.stringify(applicationSourceCoverage))
       }
     })
   })
@@ -54,7 +54,7 @@ if (Cypress.env('coverage') === false) {
             // original failed request
             return
           }
-          cy.task('combineCoverage', coverage)
+          cy.task('combineCoverage', JSON.stringify(coverage))
         })
     }
 
@@ -75,7 +75,7 @@ if (Cypress.env('coverage') === false) {
         (fileCoverage, filename) =>
           filename.startsWith(specFolder) || filename.startsWith(supportFolder)
       )
-      cy.task('combineCoverage', coverage)
+      cy.task('combineCoverage', JSON.stringify(coverage))
     }
 
     // when all tests finish, lets generate the coverage report

--- a/task.js
+++ b/task.js
@@ -61,8 +61,14 @@ module.exports = {
   /**
    * Combines coverage information from single test
    * with previously collected coverage.
+   *
+   * @param {string} sentCoverage Stringified coverage object sent by the test runner
+   * @returns {null} Nothing is returned from this task
    */
-  combineCoverage(coverage) {
+  combineCoverage(sentCoverage) {
+    const coverage = JSON.parse(sentCoverage)
+    debug('parsed sent coverage')
+
     fixSourcePathes(coverage)
     const previous = existsSync(nycFilename)
       ? JSON.parse(readFileSync(nycFilename))


### PR DESCRIPTION
- closes #26 
- closes #76 

Stringify coverage object before sending to avoid Cypress's "safe" stringify