### PR TITLE
feat: warn if missing code coverage information

### DIFF
--- a/support.js
+++ b/support.js
@@ -5,11 +5,20 @@
  * via "cy.task".
  */
 const sendCoverage = (coverage, pathname = '/') => {
-  cy.log(`Saving code coverage for **${pathname}**`)
+  logMessage(`Saving code coverage for **${pathname}**`)
   // stringify coverage object for speed
   cy.task('combineCoverage', JSON.stringify(coverage), {
     log: false
   })
+}
+
+/**
+ * Consistently logs the given string to the Command Log
+ * so the user knows the log message is coming from this plugin.
+ * @param {string} s Message to log.
+ */
+const logMessage = s => {
+  cy.log(`${s} \`[@cypress/code-coverage]\``)
 }
 
 // to disable code coverage commands and save time
@@ -60,9 +69,9 @@ if (Cypress.env('coverage') === false) {
 
     if (!hasE2ECoverage()) {
       if (hasUnitTestCoverage()) {
-        cy.log(`👉 Only found unit test code coverage.`)
+        logMessage(`👉 Only found unit test code coverage.`)
       } else {
-        cy.log(`
+        logMessage(`
           ⚠️ Could not find any coverage information in your application
           by looking at the window coverage object.
           Did you forget to instrument your application?


### PR DESCRIPTION
- closes #117 

Gives a warning if cannot find neither e2e nor unit test code coverage. The warning has a link that opens on click right inside the test runner's browser, goes to https://github.com/cypress-io/code-coverage#instrument-your-application

<img width="1279" alt="Screen Shot 2020-02-04 at 10 38 47 AM" src="https://user-images.githubusercontent.com/2212006/73760172-ff974380-473a-11ea-9997-9d6cadda0257.png">

- if there is no e2e code coverage, but at least unit test coverage gives a "note"

<img width="1122" alt="Screen Shot 2020-02-04 at 10 40 32 AM" src="https://user-images.githubusercontent.com/2212006/73760276-1ccc1200-473b-11ea-82c3-847ea8c658d6.png">


