### PR TITLE
feat: automatically resolve non-absolute paths to files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,9 +130,9 @@ workflows:
             - run:
                 name: Check code coverage 📈
                 command: |
-                  node ../../scripts/check-coverage server.js
-                  node ../../scripts/check-coverage main.js
-                  node ../../scripts/check-coverage string-utils.js
+                  node ../../scripts/check-coverage fullstack/server/server.js
+                  node ../../scripts/check-coverage fullstack/main.js
+                  node ../../scripts/check-coverage fullstack/string-utils.js
                   node ../../scripts/only-covered server.js main.js string-utils.js
                 working_directory: examples/fullstack
 

--- a/task.js
+++ b/task.js
@@ -1,6 +1,6 @@
 // @ts-check
 const istanbul = require('istanbul-lib-coverage')
-const { join, resolve } = require('path')
+const { join, resolve, isAbsolute } = require('path')
 const { existsSync, mkdirSync, readFileSync, writeFileSync } = require('fs')
 const execa = require('execa')
 const fs = require('fs')
@@ -35,6 +35,29 @@ function saveCoverage(coverage) {
   }
 
   writeFileSync(nycFilename, JSON.stringify(coverage, null, 2))
+}
+
+/**
+ * Looks at all coverage objects in the given JSON coverage file
+ * and if the file is relative, and exists, changes its path to
+ * be absolute.
+ */
+function resolvePaths(nycFilename) {
+  const nycCoverage = JSON.parse(readFileSync(nycFilename, 'utf8'))
+  Object.keys(nycCoverage).forEach(key => {
+    const coverage = nycCoverage[key]
+    if (coverage.path && !isAbsolute(coverage.path)) {
+      if (existsSync(coverage.path)) {
+        debug('resolving path %s', coverage.path)
+        coverage.path = resolve(coverage.path)
+      }
+    }
+  })
+  writeFileSync(
+    nycFilename,
+    JSON.stringify(nycCoverage, null, 2) + '\n',
+    'utf8'
+  )
 }
 
 const tasks = {
@@ -96,6 +119,8 @@ const tasks = {
       console.warn('Skipping coverage report')
       return null
     }
+
+    resolvePaths(nycFilename)
 
     if (customNycReportScript) {
       debug(

--- a/task.js
+++ b/task.js
@@ -44,20 +44,26 @@ function saveCoverage(coverage) {
  */
 function resolvePaths(nycFilename) {
   const nycCoverage = JSON.parse(readFileSync(nycFilename, 'utf8'))
+  let changed
   Object.keys(nycCoverage).forEach(key => {
     const coverage = nycCoverage[key]
     if (coverage.path && !isAbsolute(coverage.path)) {
       if (existsSync(coverage.path)) {
         debug('resolving path %s', coverage.path)
         coverage.path = resolve(coverage.path)
+        changed = true
       }
     }
   })
-  writeFileSync(
-    nycFilename,
-    JSON.stringify(nycCoverage, null, 2) + '\n',
-    'utf8'
-  )
+
+  if (changed) {
+    debug('saving updated file %s', nycFilename)
+    writeFileSync(
+      nycFilename,
+      JSON.stringify(nycCoverage, null, 2) + '\n',
+      'utf8'
+    )
+  }
 }
 
 const tasks = {


### PR DESCRIPTION
- closes #188

Before generating report, updates nyc results JSON file. If there is a non-absolute path, and file exists, changes the path to absolute. This puts files instrumented in different ways in the same report folder, allowing for better reports

## before

<img width="1109" alt="Screen Shot 2020-04-09 at 5 31 36 PM" src="https://user-images.githubusercontent.com/2212006/78943427-d9b75380-7a89-11ea-90a1-bb2fdf0443cf.png">

## after

<img width="879" alt="Screen Shot 2020-04-09 at 5 40 17 PM" src="https://user-images.githubusercontent.com/2212006/78943444-e0de6180-7a89-11ea-9106-b13ef2926852.png">
