### PR TITLE
feat: add json summary report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,6 +467,7 @@ workflows:
           store_artifacts: true
           post-steps:
             - run: cat examples/one-spec/.nyc_output/out.json
+            - run: cat examples/one-spec/coverage/coverage-summary.json
             # store the created coverage report folder
             # you can click on it in the CircleCI UI
             # to see live static HTML site

--- a/common-utils.js
+++ b/common-utils.js
@@ -26,7 +26,7 @@ function combineNycOptions({
 
 const defaultNycOptions = {
   'report-dir': './coverage',
-  reporter: ['lcov', 'clover', 'json'],
+  reporter: ['lcov', 'clover', 'json', 'json-summary'],
   extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
   excludeAfterRemap: false
 }

--- a/cypress/integration/combine-spec.js
+++ b/cypress/integration/combine-spec.js
@@ -13,7 +13,7 @@ describe('Combine NYC options', () => {
       extends: '@istanbuljs/nyc-config-typescript',
       all: true,
       'report-dir': './coverage',
-      reporter: ['lcov', 'clover', 'json'],
+      reporter: ['lcov', 'clover', 'json', 'json-summary'],
       extension: ['.js', '.cjs', '.mjs', '.ts', '.tsx', '.jsx'],
       excludeAfterRemap: false
     })


### PR DESCRIPTION
which generates report in `coverage/coverage-summary.json` like

```json
{
    "total": {
        "lines": {
            "total": 3,
            "covered": 3,
            "skipped": 0,
            "pct": 100
        },
        "statements": {
            "total": 3,
            "covered": 3,
            "skipped": 0,
            "pct": 100
        },
        "functions": {
            "total": 1,
            "covered": 1,
            "skipped": 0,
            "pct": 100
        },
        "branches": {
            "total": 0,
            "covered": 0,
            "skipped": 0,
            "pct": 100
        }
    },
    "/Users/gleb/git/instrument-example/src/App.js": {
        "lines": {
            "total": 1,
            "covered": 1,
            "skipped": 0,
            "pct": 100
        },
        "functions": {
            "total": 1,
            "covered": 1,
            "skipped": 0,
            "pct": 100
        },
        "statements": {
            "total": 1,
            "covered": 1,
            "skipped": 0,
            "pct": 100
        },
        "branches": {
            "total": 0,
            "covered": 0,
            "skipped": 0,
            "pct": 100
        }
    },
    "/Users/gleb/git/instrument-example/src/index.js": {
        "lines": {
            "total": 2,
            "covered": 2,
            "skipped": 0,
            "pct": 100
        },
        "functions": {
            "total": 0,
            "covered": 0,
            "skipped": 0,
            "pct": 100
        },
        "statements": {
            "total": 2,
            "covered": 2,
            "skipped": 0,
            "pct": 100
        },
        "branches": {
            "total": 0,
            "covered": 0,
            "skipped": 0,
            "pct": 100
        }
    }
}
```