### PR TITLE
feat: add support for other NYC configuration files

### DIFF
--- a/common-utils.js
+++ b/common-utils.js
@@ -1,18 +1,7 @@
 // @ts-check
-function combineNycOptions({
-  pkgNycOptions,
-  nycrc,
-  nycrcJson,
-  defaultNycOptions
-}) {
+function combineNycOptions(...options) {
   // last option wins
-  const nycOptions = Object.assign(
-    {},
-    defaultNycOptions,
-    nycrc,
-    nycrcJson,
-    pkgNycOptions
-  )
+  const nycOptions = Object.assign({}, ...options)
 
   if (typeof nycOptions.reporter === 'string') {
     nycOptions.reporter = [nycOptions.reporter]

--- a/cypress/integration/combine-spec.js
+++ b/cypress/integration/combine-spec.js
@@ -5,10 +5,7 @@ describe('Combine NYC options', () => {
       extends: '@istanbuljs/nyc-config-typescript',
       all: true
     }
-    const combined = combineNycOptions({
-      pkgNycOptions,
-      defaultNycOptions
-    })
+    const combined = combineNycOptions(defaultNycOptions, pkgNycOptions)
     cy.wrap(combined).should('deep.equal', {
       extends: '@istanbuljs/nyc-config-typescript',
       all: true,
@@ -23,10 +20,7 @@ describe('Combine NYC options', () => {
     const pkgNycOptions = {
       reporter: 'text'
     }
-    const combined = combineNycOptions({
-      pkgNycOptions,
-      defaultNycOptions
-    })
+    const combined = combineNycOptions(defaultNycOptions, pkgNycOptions)
     cy.wrap(combined).should('deep.equal', {
       'report-dir': './coverage',
       reporter: ['text'],
@@ -47,15 +41,19 @@ describe('Combine NYC options', () => {
       exclude: ['bar.js'],
       reporter: ['json']
     }
-    const combined = combineNycOptions({
-      pkgNycOptions,
+    const nycConfig = {
+      'report-dir': './report'
+    }
+    const combined = combineNycOptions(
+      defaultNycOptions,
       nycrc,
       nycrcJson,
-      defaultNycOptions
-    })
+      nycConfig,
+      pkgNycOptions
+    )
     cy.wrap(combined).should('deep.equal', {
       all: true,
-      'report-dir': './coverage',
+      'report-dir': './report',
       reporter: ['json'],
       extension: ['.js'],
       excludeAfterRemap: false,

--- a/cypress/integration/combine-spec.js
+++ b/cypress/integration/combine-spec.js
@@ -76,10 +76,10 @@ describe('Combine NYC options', () => {
       reporter: ['json']
     }
     const combined = combineNycOptions(
-      defaultNycOptions
+      defaultNycOptions,
       nycrc,
       nycrcJson,
-      pkgNycOptions,
+      pkgNycOptions
     )
     cy.wrap(combined).should('deep.equal', {
       all: true,

--- a/cypress/integration/combine-spec.js
+++ b/cypress/integration/combine-spec.js
@@ -75,12 +75,12 @@ describe('Combine NYC options', () => {
       exclude: 'bar.js',
       reporter: ['json']
     }
-    const combined = combineNycOptions({
-      pkgNycOptions,
+    const combined = combineNycOptions(
+      defaultNycOptions
       nycrc,
       nycrcJson,
-      defaultNycOptions
-    })
+      pkgNycOptions,
+    )
     cy.wrap(combined).should('deep.equal', {
       all: true,
       'report-dir': './coverage',

--- a/package-lock.json
+++ b/package-lock.json
@@ -4202,8 +4202,8 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "resolved": "https://packages.convoy.com:443/artifactory/api/npm/npm/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha1-vNZ5HqWuCXJeF+WtmIE0zUCz2RE=",
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -9978,9 +9978,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.14.0",
+      "resolved": "https://packages.convoy.com:443/artifactory/api/npm/npm/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha1-p6NBcPJqIbsWJCTYray0ETpp5II=",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "execa": "4.0.2",
     "globby": "11.0.0",
     "istanbul-lib-coverage": "3.0.0",
+    "js-yaml": "3.14.0",
     "nyc": "15.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for reading NYC configuration from `.nycrc.yaml`, `.nycrc.yml`, and `nyc.config.js`.

According to the [NYC docs](https://github.com/istanbuljs/nyc#configuration-files), these well-known filenames are valid place to store NYC configuration, and it's best to be comprehensive. (It's surprising to users when they think NYC is being configured properly, but it's not being read by this plugin.)