### PR TITLE
fix: merge code coverage from tests

### DIFF
--- a/support.js
+++ b/support.js
@@ -99,9 +99,10 @@ const registerHooks = () => {
       }
 
       if (
-        Cypress._.find(windowCoverageObjects, {
-          coverage: applicationSourceCoverage
-        })
+        Cypress._.find(
+          windowCoverageObjects,
+          ({ coverage }) => coverage === applicationSourceCoverage
+        )
       ) {
         // this application code coverage object is already known
         // which can happen when combining `window:load` and `before` callbacks


### PR DESCRIPTION
Checking strict equality to find known coverage object, so that coverage from two tests for a same page can be merged.