### PR TITLE
fix: add recursive=true to mkdirSync when creating output folder

### DIFF
--- a/task.js
+++ b/task.js
@@ -61,7 +61,7 @@ const nycFilename = join(nycReportOptions['temp-dir'], 'out.json')
 
 function saveCoverage(coverage) {
   if (!existsSync(nycReportOptions.tempDir)) {
-    mkdirSync(nycReportOptions.tempDir)
+    mkdirSync(nycReportOptions.tempDir, { recursive: true })
     debug('created folder %s for output coverage', nycReportOptions.tempDir)
   }
 


### PR DESCRIPTION
After configuring nyc with

```
    "report-dir": "cypress/test-results/coverage",
    "reporter": "json",
    "temp-dir": "cypress/test-results/coverage/.nyc_output"
```

I observed the following error when starting the tests in a fresh repo clone:

![ENOENT: no such file or directory, mkdir '/path/to/project/cypress/test-results/coverage/.nyc_output'](https://user-images.githubusercontent.com/608862/104354749-977fde80-5501-11eb-81af-9dab4bc372b6.png).

This PR fixes this by recursively creating all subfolders that are needed to satisfy the config.