### PR TITLE
Remove call to deprecated Cypress.moment()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6962,6 +6962,12 @@
       "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.4.tgz",
+      "integrity": "sha512-RI/Hh4kqRc1UKLOAf/T5zdMMX5DQIlDxwUe3wSyMMnEbGunnpENCdbUgM+dW7kXidZqCttBrmw7BhN4TMddkCw==",
+      "dev": true
+    },
     "deasync": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "check-code-coverage": "1.10.0",
     "console-log-div": "0.6.3",
     "cypress": "6.3.0",
+    "dayjs": "^1.10.4",
     "express": "4.17.1",
     "lodash": "4.17.20",
     "markdown-link-check": "3.8.6",

--- a/support.js
+++ b/support.js
@@ -1,7 +1,11 @@
 /// <reference types="cypress" />
 // @ts-check
 
+const dayjs = require('dayjs')
+var duration = require('dayjs/plugin/duration')
 const { filterSpecsFromCoverage } = require('./support-utils')
+
+dayjs.extend(duration)
 
 /**
  * Sends collected code coverage object to the backend code
@@ -226,7 +230,7 @@ const registerHooks = () => {
       message: ['Generating report [@cypress/code-coverage]']
     })
     cy.task('coverageReport', null, {
-      timeout: Cypress.moment.duration(3, 'minutes').asMilliseconds(),
+      timeout: dayjs.duration(3, 'minutes').asMilliseconds(),
       log: false
     }).then((coverageReportFolder) => {
       logInstance.set('consoleProps', () => ({


### PR DESCRIPTION
Cypress.moment() will be removed in upcoming 7.0 release