### PR TITLE
deps: make @cypress/browserify-preprocessor peer dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,6 +56,8 @@ workflows:
       - unit
 
       - cypress/install:
+          # npm ci is the default, but we need the peer dependency as well
+          install-command: npm ci && npm install --save false --package-lock false @cypress/browserify-preprocessor
           post-steps:
             - run: npm run check:markdown
 

--- a/README.md
+++ b/README.md
@@ -110,10 +110,10 @@ Watch video [How to read code coverage report](https://youtu.be/yVvCYtsmkZU) to 
 
 If you test your application code directly from `specs` you might want to instrument them and combine unit test code coverage with any end-to-end code coverage (from iframe). You can easily instrument spec files using [babel-plugin-istanbul](https://github.com/istanbuljs/babel-plugin-istanbul) for example.
 
-Install the plugin
+Install the plugin and the preprocessor
 
 ```
-npm i -D babel-plugin-istanbul
+npm i -D babel-plugin-istanbul @cypress/browserify-preprocessor
 ```
 
 Set your `.babelrc` file

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "types": "tsc --noEmit --allowJs *.js cypress/integration/*.js"
   },
   "peerDependencies": {
-    "cypress": "*"
+    "cypress": "*",
+    "@cypress/browserify-preprocessor": "3.0.1"
   },
   "repository": {
     "type": "git",
@@ -47,7 +48,6 @@
   },
   "private": false,
   "dependencies": {
-    "@cypress/browserify-preprocessor": "3.0.1",
     "dayjs": "1.10.7",
     "debug": "4.3.2",
     "execa": "4.1.0",


### PR DESCRIPTION
If you don't have unit tests (or want to instrument the code differently),
you don't need browserify-preprocessor.

The hard dependency can also add unnecessary modules, because
browserify-preprocessor uses an exact @babel/core dependency.

This is a redo of https://github.com/cypress-io/code-coverage/pull/37 (thanks @rndmerle ), hopefully with the correct circle-ci config. We'll see.