### PR TITLE
add TypeScript definition to task.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "homepage": "https://github.com/cypress-io/code-coverage#readme",
   "files": [
+    "*.d.ts",
     "*.js",
     "middleware"
   ],

--- a/task.d.ts
+++ b/task.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="cypress" />
+
+export default function registerCodeCoverageTasks(
+  on: Cypress.PluginEvents,
+  config: Cypress.PluginConfigOptions,
+): void;


### PR DESCRIPTION
## Fixes error in IDE:
![image](https://user-images.githubusercontent.com/343837/148662599-4e0ca0ab-fb67-4913-93d7-48f86c6eabb6.png)

## Fixes error in CI:
```
/.../cypress/plugins/index.ts
  13:3  error  Unsafe call of an `any` typed value  @typescript-eslint/no-unsafe-call
```

## Workaround

I've been copy-pasting this between repos, which is a poor developer experience, but it's also now not working in monorepos, because it's existence in the root directory is not picked up by the workspace-specific linter.

```typescript
declare module '@cypress/code-coverage/task' {
  import 'cypress';
  export default function registerCodeCoverageTasks(
    on: Cypress.PluginEvents,
    // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
    config: Cypress.PluginConfigOptions,
  ): void;
}
```

The aim of this PR is to apply the workaround solution to this repository such that the workaround is no longer required.