### PR TITLE
feat: support CJS configs in ES packages

### DIFF
--- a/task-utils.js
+++ b/task-utils.js
@@ -62,6 +62,16 @@ function readNycOptions(workingDirectory) {
     }
   }
 
+  const nycConfigCommonJsFilename = join(workingDirectory, 'nyc.config.cjs')
+  let nycConfigCommonJs = {}
+  if (existsSync(nycConfigCommonJsFilename)) {
+    try {
+      nycConfigCommonJs = require(nycConfigCommonJsFilename)
+    } catch (error) {
+      throw new Error(`Failed to load nyc.config.cjs: ${error.message}`)
+    }
+  }
+
   const nycOptions = combineNycOptions(
     defaultNycOptions,
     nycrc,
@@ -69,6 +79,7 @@ function readNycOptions(workingDirectory) {
     nycrcYaml,
     nycrcYml,
     nycConfig,
+    nycConfigCommonJs,
     pkgNycOptions
   )
   debug('combined NYC options %o', nycOptions)


### PR DESCRIPTION
# Problem statement

When writing an application with `"type": "module"` in `package.json`, it becomes _impossible_ to set the NYC config with JS, since it only supports the `.js` extension and it only supports CommonJS. As a result, any configuration in `nyc.config.js` will fail for trying to `require` an ES module.

This PR adds support for `nyc.config.cjs`, allowing packages with `"type": "module"` to still configure a `nyc.config.cjs` file for a CommonJS configuration.