### PR TITLE
feat: Add option to specify custom folder from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,17 @@ You can specify custom report folder by adding `nyc` object to the `package.json
 }
 ```
 
+In cases, the report folder needs to be set programmatically or outside the root folder config, you can specify it in the plugins. You can modify `reportDir` in the config when passing it to the code-coverage task.
+
+```js
+module.exports = (on, config) => {
+  config.reportDir = 'reports/cypress-report'
+  require('@cypress/code-coverage/task')(on, config)
+  return config
+}
+```
+
+
 ## Custom reporters
 
 You can specify custom coverage reporter(s) to use. For example to output text summary and save JSON report in `cypress-coverage` folder set in your `package.json` folder:

--- a/task.js
+++ b/task.js
@@ -31,7 +31,7 @@ const scripts = pkg.scripts || {}
 const DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME = 'coverage:report'
 const customNycReportScript = scripts[DEFAULT_CUSTOM_COVERAGE_SCRIPT_NAME]
 
-const nycReportOptions = (function getNycOption() {
+const nycReportOptions = (function getNycOption(a) {
   // https://github.com/istanbuljs/nyc#common-configuration-options
   const nycReportOptions = readNycOptions(processWorkingDirectory)
 
@@ -109,7 +109,7 @@ function maybePrintFinalCoverageFiles(folder) {
   })
 }
 
-const tasks = {
+const createTasks = (config) => ({
   /**
    * Clears accumulated code coverage information.
    *
@@ -207,10 +207,15 @@ const tasks = {
     debug('calling NYC reporter with options %o', nycReportOptions)
     debug('current working directory is %s', process.cwd())
     const NYC = require('nyc')
-    const nyc = new NYC(nycReportOptions)
+    const nyc = new NYC({
+      ...nycReportOptions,
+      reportDir: config.reportDir
+        ? config.reportDir
+        : nycReportOptions.reportDir
+    })
 
     const returnReportFolder = () => {
-      const reportFolder = nycReportOptions['report-dir']
+      const reportFolder = config.reportDir || nycReportOptions['report-dir']
       debug(
         'after reporting, returning the report folder name %s',
         reportFolder
@@ -222,7 +227,7 @@ const tasks = {
     }
     return nyc.report().then(returnReportFolder)
   }
-}
+})
 
 /**
  * Registers code coverage collection and reporting tasks.
@@ -240,7 +245,7 @@ const tasks = {
   ```
 */
 function registerCodeCoverageTasks(on, config) {
-  on('task', tasks)
+  on('task', createTasks(config))
 
   // set a variable to let the hooks running in the browser
   // know that they can send coverage commands


### PR DESCRIPTION
This PR resolved issue #107. Sometimes the code-coverage can be installed not in the root cwd folder (for example in monorepo / microservices setup). With this change it will be possible to specify output directory via config, when connecting the task to the cypress plugins