### PR TITLE
update peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,11 @@
     "effective:config": "circleci config process .circleci/config.yml | sed /^#/d"
   },
   "peerDependencies": {
-    "cypress": "*"
+    "@babel/core": "^7.0.0",
+    "@babel/preset-env": "^7.0.0",
+    "babel-loader": "^8.0.0",
+    "cypress": "*",
+    "webpack": "^5.0.0"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "effective:config": "circleci config process .circleci/config.yml | sed /^#/d"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.0",
+    "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.0.0",
+    "babel-loader": "^8.3 || ^9",
     "cypress": "*",
-    "webpack": "^5.0.0"
+    "webpack": "^4 || ^5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Resolves this warning when installing `@cypress/code-coverage` by accurately marking these as peer dependencies (vended from other sources instead of this package's own dependencies):

```
➤ YN0002: │ @cypress/code-coverage@npm:3.10.0 [6241e] doesn't provide @babel/core (p8cbc9), 
requested by @cypress/webpack-preprocessor
➤ YN0002: │ @cypress/code-coverage@npm:3.10.0 [6241e] doesn't provide @babel/preset-env (p3f0bc), requested by @cypress/webpack-preprocessor
➤ YN0002: │ @cypress/code-coverage@npm:3.10.0 [6241e] doesn't provide babel-loader (p93203), requested by @cypress/webpack-preprocessor
➤ YN0002: │ @cypress/code-coverage@npm:3.10.0 [6241e] doesn't provide webpack (pb20d7), requested by @cypress/webpack-preprocessor
```