### PR TITLE
Update nyc options "exclude" error message

### DIFF
--- a/task.js
+++ b/task.js
@@ -37,7 +37,7 @@ const nycReportOptions = (function getNycOption() {
 
   if (nycReportOptions.exclude && !Array.isArray(nycReportOptions.exclude)) {
     console.error('NYC options: %o', nycReportOptions)
-    throw new Error('Expected "exclude" to by an array')
+    throw new Error('Expected "exclude" to be an array')
   }
 
   if (nycReportOptions['temp-dir']) {


### PR DESCRIPTION
Just a quick typo fix ("by" -> "be") in the error message thrown when the nyc `exclude` option value is not an array.