### PR TITLE
chore: update cypress and windows orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,15 +1,18 @@
+defaultCypressOrbConfig: &defaultCypressOrbConfig
+  executor: cypress/default
+
 # https://circleci.com/docs/2.0/configuration-reference/
 version: 2.1
 orbs:
   # https://github.com/cypress-io/circleci-orb
-  cypress: cypress-io/cypress@1.29.0 # used to run e2e tests
+  cypress: cypress-io/cypress@3.0.0 # used to run e2e tests
   win: circleci/windows@2 # run a test job on Windows
 
 jobs:
   lint:
     description: Checks the code formatting
     docker:
-      - image: cimg/node:16.9.1
+      - image: cimg/node:16.16.0
         environment:
           # we don't need Cypress to check code styl
           CYPRESS_INSTALL_BINARY: '0'
@@ -20,11 +23,76 @@ jobs:
           name: Code style check 🧹
           command: npm run format:check
       - run: npm run check:markdown
+  
+  install_and_persist:
+    <<: *defaultCypressOrbConfig
+    steps:
+      - cypress/install
+      - run:
+          name: Install deps for test-apps/old-cypress-config
+          command: npm ci
+          working_directory: test-apps/old-cypress-config
+      - run:
+          name: Install deps for test-apps/new-cypress-config
+          command: npm ci
+          working_directory: test-apps/new-cypress-config
+      - run: npm run check:markdown
+      - persist_to_workspace:
+          paths:
+              - .cache/Cypress
+              - project
+          root: ~/
+    # windows_test:
+    #   executor:
+    #     # executor comes from the "windows" orb
+    #     name: win/default
+    #     shell: bash.exe
+    #   steps:
+    #     - cypress/run:
+    #         # no-workspace: true
+    #         start-command: npm run start:windows --prefix test-apps/old-cypress-config/all-files
+    #         # wait-on: 'http://localhost:1234'
+    #         cypress-command: npx cypress run --project test-apps/old-cypress-config/all-files
+    #         # store screenshots and videos
+    #         # store_artifacts: true
+    #   post-checkout:
+    #     - run:
+    #         name: Install node 16
+    #         command: nvm install 16.16.0
+    #     - run:
+    #         name: Use node 16
+    #         command: nvm use 16.16.0
+    #     - run:
+    #         name: Install deps for code coverage
+    #         command: npm ci
+    #   post-install:
+    #     - run:
+    #         name: Install deps for test-apps/old-cypress-config
+    #         command: npm ci
+    #         working_directory: test-apps/old-cypress-config            
+    #   post-steps:
+    #     # store the created coverage report folder
+    #     # you can click on it in the CircleCI UI
+    #     # to see live static HTML site
+    #     - store_artifacts:
+    #         path: test-apps/old-cypress-config/all-files/coverage
+    #     # make sure the examples captures 100% of code
+    #     - run:
+    #         name: Verify Code Coverage
+    #         command: npm run coverage:verify
+    #         working_directory: test-apps/old-cypress-config/all-files
+    #     - run:
+    #         name: Check code coverage files 📈
+    #         # we will check the final coverage report
+    #         # to make sure it only has files we are interested in
+    #         # because there are files covered at 0 in the report
+    #         command: npm i -D check-code-coverage && npm run coverage:check-files:windows
+    #         working_directory: test-apps/old-cypress-config/all-files
 
   publish:
     description: Publishes the new version of the plugin to NPM
     docker:
-      - image: cimg/node:16.9.1
+      - image: cimg/node:16.16.0
     environment:
       # we don't need Cypress to do the release
       CYPRESS_INSTALL_BINARY: '0'
@@ -40,7 +108,7 @@ jobs:
 
   cyrun:
     docker:
-      - image: cypress/base:16.13.2
+      - image: cypress/base:16.16.0
     parameters:
       jobname:
         type: string
@@ -66,13 +134,10 @@ jobs:
 
   test-code-coverage-plugin:
     docker:
-      - image: cypress/base:16.13.2
+      - image: cypress/base:16.16.0
     steps:
       - attach_workspace:
           at: ~/
-      - run:
-          name: Install deps
-          command: npm ci
       - run:
           command: npm run test
       - store_artifacts:
@@ -84,34 +149,19 @@ jobs:
 workflows:
   build:
     jobs:
-      - cypress/install:
-          cache-key: 'cache-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}'
-          pre-steps:
-            - run: npm i -g npm@latest
-          post-install:
-            - run:
-                name: Install deps for test-apps/old-cypress-config
-                command: npm ci
-                working_directory: test-apps/old-cypress-config
-            - run:
-                name: Install deps for test-apps/new-cypress-config
-                command: npm ci
-                working_directory: test-apps/new-cypress-config
-          post-steps:
-            - run: npm run check:markdown 
-
+      - install_and_persist
       - lint:
           requires:
-            - cypress/install
+            - install_and_persist
 
       - test-code-coverage-plugin:
           requires:
-            - cypress/install
+            - install_and_persist
 
       - cyrun:
           name: test-<< matrix.jobname>>
           requires:
-            - cypress/install
+            - install_and_persist
           matrix:
             parameters:
               jobname:
@@ -143,89 +193,88 @@ workflows:
                 - new-cypress-config/unit-tests-js
                 - new-cypress-config/use-webpack
 
-      - cypress/run:
-          name: Windows test
-          executor:
-            # executor comes from the "windows" orb
-            name: win/default
-            shell: bash.exe
-          no-workspace: true
-          start: npm run start:windows --prefix test-apps/old-cypress-config/all-files
-          wait-on: 'http://localhost:1234'
-          command: npx cypress run --project test-apps/old-cypress-config/all-files
-          # store screenshots and videos
-          store_artifacts: true
-          cache-key: 'cache-{{ arch }}-{{ .Branch }}-{{ checksum "package-lock.json" }}'
-          post-checkout:
-            - run:
-                name: Install node 16
-                command: nvm install 16.13.2
-            - run:
-                name: Use node 16
-                command: nvm use 16.13.2
-            - run:
-                name: Install deps for code coverage
-                command: npm ci
-          post-install:
-            - run:
-                name: Install deps for test-apps/old-cypress-config
-                command: npm ci
-                working_directory: test-apps/old-cypress-config            
-          post-steps:
-            # store the created coverage report folder
-            # you can click on it in the CircleCI UI
-            # to see live static HTML site
-            - store_artifacts:
-                path: test-apps/old-cypress-config/all-files/coverage
-            # make sure the examples captures 100% of code
-            - run:
-                name: Verify Code Coverage
-                command: npm run coverage:verify
-                working_directory: test-apps/old-cypress-config/all-files
-            - run:
-                name: Check code coverage files 📈
-                # we will check the final coverage report
-                # to make sure it only has files we are interested in
-                # because there are files covered at 0 in the report
-                command: npm i -D check-code-coverage && npm run coverage:check-files:windows
-                working_directory: test-apps/old-cypress-config/all-files
+      # - cypress/run:
+      #     name: Windows test
+      #     executor:
+      #       # executor comes from the "windows" orb
+      #       name: win/default
+      #       shell: bash.exe
+      #     # no-workspace: true
+      #     start-command: npm run start:windows --prefix test-apps/old-cypress-config/all-files
+      #     # wait-on: 'http://localhost:1234'
+      #     cypress-command: npx cypress run --project test-apps/old-cypress-config/all-files
+      #     # store screenshots and videos
+      #     # store_artifacts: true
+      #     post-checkout:
+      #       - run:
+      #           name: Install node 16
+      #           command: nvm install 16.16.0
+      #       - run:
+      #           name: Use node 16
+      #           command: nvm use 16.16.0
+      #       - run:
+      #           name: Install deps for code coverage
+      #           command: npm ci
+      #     post-install:
+      #       - run:
+      #           name: Install deps for test-apps/old-cypress-config
+      #           command: npm ci
+      #           working_directory: test-apps/old-cypress-config            
+      #     post-steps:
+      #       # store the created coverage report folder
+      #       # you can click on it in the CircleCI UI
+      #       # to see live static HTML site
+      #       - store_artifacts:
+      #           path: test-apps/old-cypress-config/all-files/coverage
+      #       # make sure the examples captures 100% of code
+      #       - run:
+      #           name: Verify Code Coverage
+      #           command: npm run coverage:verify
+      #           working_directory: test-apps/old-cypress-config/all-files
+      #       - run:
+      #           name: Check code coverage files 📈
+      #           # we will check the final coverage report
+      #           # to make sure it only has files we are interested in
+      #           # because there are files covered at 0 in the report
+      #           command: npm i -D check-code-coverage && npm run coverage:check-files:windows
+      #           working_directory: test-apps/old-cypress-config/all-files
 
-      - publish:
-          filters:
-            branches:
-              only:
-                - master
-                - beta
-                - next
-                - dev
-          requires:
-            - lint
-            - test-code-coverage-plugin
-            - test-old-cypress-config/all-files
-            - test-old-cypress-config/backend
-            - test-old-cypress-config/before-all-visit
-            - test-old-cypress-config/before-each-visit
-            - test-old-cypress-config/exclude-files
-            - test-old-cypress-config/frontend
-            - test-old-cypress-config/fullstack
-            - test-old-cypress-config/one-spec
-            - test-old-cypress-config/same-folder
-            - test-old-cypress-config/support-files
-            - test-old-cypress-config/ts-example
-            - test-old-cypress-config/unit-tests-js
-            - test-old-cypress-config/use-webpack
-            - test-new-cypress-config/all-files
-            - test-new-cypress-config/backend
-            - test-new-cypress-config/before-all-visit
-            - test-new-cypress-config/before-each-visit
-            - test-new-cypress-config/cra-e2e-and-ct
-            - test-new-cypress-config/exclude-files
-            - test-new-cypress-config/frontend
-            - test-new-cypress-config/fullstack
-            - test-new-cypress-config/one-spec
-            - test-new-cypress-config/same-folder
-            - test-new-cypress-config/support-files
-            - test-new-cypress-config/ts-example
-            - test-new-cypress-config/unit-tests-js
-            - test-new-cypress-config/use-webpack
-            - Windows test
+      # - publish:
+      #     filters:
+      #       branches:
+      #         only:
+      #           - master
+      #           - beta
+      #           - next
+      #           - dev
+      #     requires:
+      #       - lint
+      #       - test-code-coverage-plugin
+      #       - test-old-cypress-config/all-files
+      #       - test-old-cypress-config/backend
+      #       - test-old-cypress-config/before-all-visit
+      #       - test-old-cypress-config/before-each-visit
+      #       - test-old-cypress-config/exclude-files
+      #       - test-old-cypress-config/frontend
+      #       - test-old-cypress-config/fullstack
+      #       - test-old-cypress-config/one-spec
+      #       - test-old-cypress-config/same-folder
+      #       - test-old-cypress-config/support-files
+      #       - test-old-cypress-config/ts-example
+      #       - test-old-cypress-config/unit-tests-js
+      #       - test-old-cypress-config/use-webpack
+      #       - test-new-cypress-config/all-files
+      #       - test-new-cypress-config/backend
+      #       - test-new-cypress-config/before-all-visit
+      #       - test-new-cypress-config/before-each-visit
+      #       - test-new-cypress-config/cra-e2e-and-ct
+      #       - test-new-cypress-config/exclude-files
+      #       - test-new-cypress-config/frontend
+      #       - test-new-cypress-config/fullstack
+      #       - test-new-cypress-config/one-spec
+      #       - test-new-cypress-config/same-folder
+      #       - test-new-cypress-config/support-files
+      #       - test-new-cypress-config/ts-example
+      #       - test-new-cypress-config/unit-tests-js
+      #       - test-new-cypress-config/use-webpack
+      #       - Windows test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,9 @@
-defaultCypressOrbConfig: &defaultCypressOrbConfig
-  executor: cypress/default
-
 # https://circleci.com/docs/2.0/configuration-reference/
 version: 2.1
 orbs:
   # https://github.com/cypress-io/circleci-orb
   cypress: cypress-io/cypress@3.0.0 # used to run e2e tests
-  win: circleci/windows@2 # run a test job on Windows
+  win: circleci/windows@5.0.0 # run a test job on Windows
 
 jobs:
   lint:
@@ -25,7 +22,7 @@ jobs:
       - run: npm run check:markdown
   
   install_and_persist:
-    <<: *defaultCypressOrbConfig
+    executor: cypress/default
     steps:
       - cypress/install
       - run:
@@ -42,52 +39,46 @@ jobs:
               - .cache/Cypress
               - project
           root: ~/
-    # windows_test:
-    #   executor:
-    #     # executor comes from the "windows" orb
-    #     name: win/default
-    #     shell: bash.exe
-    #   steps:
-    #     - cypress/run:
-    #         # no-workspace: true
-    #         start-command: npm run start:windows --prefix test-apps/old-cypress-config/all-files
-    #         # wait-on: 'http://localhost:1234'
-    #         cypress-command: npx cypress run --project test-apps/old-cypress-config/all-files
-    #         # store screenshots and videos
-    #         # store_artifacts: true
-    #   post-checkout:
-    #     - run:
-    #         name: Install node 16
-    #         command: nvm install 16.16.0
-    #     - run:
-    #         name: Use node 16
-    #         command: nvm use 16.16.0
-    #     - run:
-    #         name: Install deps for code coverage
-    #         command: npm ci
-    #   post-install:
-    #     - run:
-    #         name: Install deps for test-apps/old-cypress-config
-    #         command: npm ci
-    #         working_directory: test-apps/old-cypress-config            
-    #   post-steps:
-    #     # store the created coverage report folder
-    #     # you can click on it in the CircleCI UI
-    #     # to see live static HTML site
-    #     - store_artifacts:
-    #         path: test-apps/old-cypress-config/all-files/coverage
-    #     # make sure the examples captures 100% of code
-    #     - run:
-    #         name: Verify Code Coverage
-    #         command: npm run coverage:verify
-    #         working_directory: test-apps/old-cypress-config/all-files
-    #     - run:
-    #         name: Check code coverage files 📈
-    #         # we will check the final coverage report
-    #         # to make sure it only has files we are interested in
-    #         # because there are files covered at 0 in the report
-    #         command: npm i -D check-code-coverage && npm run coverage:check-files:windows
-    #         working_directory: test-apps/old-cypress-config/all-files
+
+  windows_test:
+    executor:
+      # executor comes from the "windows" orb
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - run:
+          name: Install node 16
+          command: nvm install 16.16.0
+      - run:
+          name: Use node 16
+          command: nvm use 16.16.0
+      - run:
+          name: Install deps for code coverage
+          command: npm ci 
+      - run:
+          name: Install deps for test-apps/old-cypress-config
+          command: npm ci
+          working_directory: test-apps/old-cypress-config   
+      - cypress/run-tests:
+          # no-workspace: true
+          start-command: npm run start:windows --prefix test-apps/old-cypress-config/all-files
+          # wait-on: 'http://localhost:1234'
+          cypress-command: npx cypress run --project test-apps/old-cypress-config/all-files
+          # store screenshots and videos
+          # store_artifacts: true          
+      - run:
+          # make sure the examples captures 100% of code
+          name: Verify Code Coverage
+          command: npm run coverage:verify
+          working_directory: test-apps/old-cypress-config/all-files
+      - run:
+          name: Check code coverage files 📈
+          # we will check the final coverage report
+          # to make sure it only has files we are interested in
+          # because there are files covered at 0 in the report
+          command: npm i -D check-code-coverage && npm run coverage:check-files:windows
+          working_directory: test-apps/old-cypress-config/all-files
 
   publish:
     description: Publishes the new version of the plugin to NPM
@@ -192,89 +183,43 @@ workflows:
                 - new-cypress-config/ts-example
                 - new-cypress-config/unit-tests-js
                 - new-cypress-config/use-webpack
-
-      # - cypress/run:
-      #     name: Windows test
-      #     executor:
-      #       # executor comes from the "windows" orb
-      #       name: win/default
-      #       shell: bash.exe
-      #     # no-workspace: true
-      #     start-command: npm run start:windows --prefix test-apps/old-cypress-config/all-files
-      #     # wait-on: 'http://localhost:1234'
-      #     cypress-command: npx cypress run --project test-apps/old-cypress-config/all-files
-      #     # store screenshots and videos
-      #     # store_artifacts: true
-      #     post-checkout:
-      #       - run:
-      #           name: Install node 16
-      #           command: nvm install 16.16.0
-      #       - run:
-      #           name: Use node 16
-      #           command: nvm use 16.16.0
-      #       - run:
-      #           name: Install deps for code coverage
-      #           command: npm ci
-      #     post-install:
-      #       - run:
-      #           name: Install deps for test-apps/old-cypress-config
-      #           command: npm ci
-      #           working_directory: test-apps/old-cypress-config            
-      #     post-steps:
-      #       # store the created coverage report folder
-      #       # you can click on it in the CircleCI UI
-      #       # to see live static HTML site
-      #       - store_artifacts:
-      #           path: test-apps/old-cypress-config/all-files/coverage
-      #       # make sure the examples captures 100% of code
-      #       - run:
-      #           name: Verify Code Coverage
-      #           command: npm run coverage:verify
-      #           working_directory: test-apps/old-cypress-config/all-files
-      #       - run:
-      #           name: Check code coverage files 📈
-      #           # we will check the final coverage report
-      #           # to make sure it only has files we are interested in
-      #           # because there are files covered at 0 in the report
-      #           command: npm i -D check-code-coverage && npm run coverage:check-files:windows
-      #           working_directory: test-apps/old-cypress-config/all-files
-
-      # - publish:
-      #     filters:
-      #       branches:
-      #         only:
-      #           - master
-      #           - beta
-      #           - next
-      #           - dev
-      #     requires:
-      #       - lint
-      #       - test-code-coverage-plugin
-      #       - test-old-cypress-config/all-files
-      #       - test-old-cypress-config/backend
-      #       - test-old-cypress-config/before-all-visit
-      #       - test-old-cypress-config/before-each-visit
-      #       - test-old-cypress-config/exclude-files
-      #       - test-old-cypress-config/frontend
-      #       - test-old-cypress-config/fullstack
-      #       - test-old-cypress-config/one-spec
-      #       - test-old-cypress-config/same-folder
-      #       - test-old-cypress-config/support-files
-      #       - test-old-cypress-config/ts-example
-      #       - test-old-cypress-config/unit-tests-js
-      #       - test-old-cypress-config/use-webpack
-      #       - test-new-cypress-config/all-files
-      #       - test-new-cypress-config/backend
-      #       - test-new-cypress-config/before-all-visit
-      #       - test-new-cypress-config/before-each-visit
-      #       - test-new-cypress-config/cra-e2e-and-ct
-      #       - test-new-cypress-config/exclude-files
-      #       - test-new-cypress-config/frontend
-      #       - test-new-cypress-config/fullstack
-      #       - test-new-cypress-config/one-spec
-      #       - test-new-cypress-config/same-folder
-      #       - test-new-cypress-config/support-files
-      #       - test-new-cypress-config/ts-example
-      #       - test-new-cypress-config/unit-tests-js
-      #       - test-new-cypress-config/use-webpack
-      #       - Windows test
+      - windows_test
+      - publish:
+          filters:
+            branches:
+              only:
+                - master
+                - beta
+                - next
+                - dev
+          requires:
+            - lint
+            - test-code-coverage-plugin
+            - test-old-cypress-config/all-files
+            - test-old-cypress-config/backend
+            - test-old-cypress-config/before-all-visit
+            - test-old-cypress-config/before-each-visit
+            - test-old-cypress-config/exclude-files
+            - test-old-cypress-config/frontend
+            - test-old-cypress-config/fullstack
+            - test-old-cypress-config/one-spec
+            - test-old-cypress-config/same-folder
+            - test-old-cypress-config/support-files
+            - test-old-cypress-config/ts-example
+            - test-old-cypress-config/unit-tests-js
+            - test-old-cypress-config/use-webpack
+            - test-new-cypress-config/all-files
+            - test-new-cypress-config/backend
+            - test-new-cypress-config/before-all-visit
+            - test-new-cypress-config/before-each-visit
+            - test-new-cypress-config/cra-e2e-and-ct
+            - test-new-cypress-config/exclude-files
+            - test-new-cypress-config/frontend
+            - test-new-cypress-config/fullstack
+            - test-new-cypress-config/one-spec
+            - test-new-cypress-config/same-folder
+            - test-new-cypress-config/support-files
+            - test-new-cypress-config/ts-example
+            - test-new-cypress-config/unit-tests-js
+            - test-new-cypress-config/use-webpack
+            - windows_test


### PR DESCRIPTION
- updates the cypress orb to v3, which allows ours CI job to continue running by implicitly upgrading the install version of node from v12 to v16
 - also bumps the windows orbs to latest to get a non broken version of `windows-nvm`