### PR TITLE
Skip test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,23 @@ For example, if you want to only include files in the `app` folder, but exclude 
 
 Another important option is `excludeAfterRemap`. By default it is false, which might let excluded files through. If you are excluding the files, and the instrumenter does not respect the `nyc.exclude` setting, then add `excludeAfterRemap: true` to tell `nyc report` to exclude files. See [test-apps/exclude-files](test-apps/new-cypress-config/exclude-files).
 
+
+## Skip test coverage collection for single spec file
+
+Skip test coverage collection from being reported for a single spec file by using the test config object by setting `{skipTestCoverage : true}`.  This will skip the execution of all hooks associated with code coverage collection.  The test will still be included in the test suite but coverage values will not be collected or added to the code coverage report. 
+
+
+```js
+describe('excludes test from code coverage reporting', {skipTestCoverage: true}, () => {
+  it(
+    'test expects 1 to equal 1',
+    { skipTestCoverage: true },
+    () => {
+      expect(1).to.equal(1)
+    },
+  )
+})
+```
 ## Disable plugin
 
 You can skip the client-side code coverage hooks by setting the environment variable `coverage` to `false`.

--- a/support.js
+++ b/support.js
@@ -40,6 +40,11 @@ const registerHooks = () => {
   const hasUnitTestCoverage = () => Boolean(window.__coverage__)
 
   before(() => {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // we need to reset the coverage when running
     // in the interactive mode, otherwise the counters will
     // keep increasing every time we rerun the tests
@@ -61,6 +66,11 @@ const registerHooks = () => {
   })
 
   beforeEach(() => {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // each object will have the coverage and url pathname
     // to let the user know the coverage has been collected
     windowCoverageObjects = []
@@ -96,6 +106,11 @@ const registerHooks = () => {
   })
 
   afterEach(() => {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // save coverage after the test
     // because now the window coverage objects have been updated
     windowCoverageObjects.forEach((cover) => {
@@ -124,6 +139,11 @@ const registerHooks = () => {
   })
 
   after(function collectBackendCoverage() {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // I wish I could fail the tests if there is no code coverage information
     // but throwing an error here does not fail the test run due to
     // https://github.com/cypress-io/cypress/issues/2296
@@ -178,6 +198,11 @@ const registerHooks = () => {
   })
 
   after(function mergeUnitTestCoverage() {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // collect and merge frontend coverage
 
     // if spec bundle has been instrumented (using Cypress preprocessor)
@@ -192,6 +217,11 @@ const registerHooks = () => {
   })
 
   after(function generateReport() {
+    // skip test coverage collection for single spec file if true 
+    // @ts-ignore
+    if (this.currentTest._testConfig.unverifiedTestConfig.skipTestCoverage) {
+      return;
+    }
     // when all tests finish, lets generate the coverage report
     const logInstance = Cypress.log({
       name: 'Coverage',


### PR DESCRIPTION
This merge request allows skipping the hooks to generate code coverage reports by using the test config object.  

## **Problem Statement:** 
I had a test that was consistently failing due to the node process that writes the coverage reports in the afterEach hook causing the pipeline to fail, possibly due to too much memory.  I am unable to upgrade to Cypress 12 to test if the memory enhancements included would solve my issue in the pipeline.  I was in search of a solution that would 1) generate a code coverage report, 2) exclude this particular test from the code coverage reporting, and 3) have the test continue alongside the other tests that were passing and collecting code coverage successfully.  

By combining the solution described here: https://glebbahmutov.com/blog/skip-before-each-hook/ I was able to successfully meet my solution goals as described above.  I was able to get a passing pipeline, collect code coverage for all other tests, and exclude the problematic test from the code coverage report thereby eliminating the pipeline crash.  

## **Feature Request:** 
I am requesting a feature to be added to the package that will enable skipping code coverage collection per test file.  Allow passing `{skipTestCoverage: true}` in order to stop the execution of the code-coverage hooks in all stages (before, beforeEach, after, afterEach) for a single test file.  This particular feature may also be of value in other ways, allowing not only the exclusion of instrumented files but also test files from test coverage reports proving more accurate results.    

```js
describe('excludes test from code coverage reporting', {skipTestCoverage: true}, () => {
  it(
    'test expects 1 to equal 1',
    { skipTestCoverage: true },
    () => {
      expect(1).to.equal(1)
    },
  )
})
```

