### PR TITLE
exclude test-apps from snyk

### DIFF
--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Perform SCA Scan
         continue-on-error: false
         run: |
-          snyk test --all-projects --detection-depth=4 --exclude=docker,Dockerfile,test-apps/* --severity-threshold=critical
+          snyk test --all-projects --detection-depth=4 --exclude=docker,Dockerfile,test-apps --severity-threshold=critical
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}

--- a/.github/workflows/snyk_sca_scan.yaml
+++ b/.github/workflows/snyk_sca_scan.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Perform SCA Scan
         continue-on-error: false
         run: |
-          snyk test --all-projects --detection-depth=4 --exclude=docker,Dockerfile --severity-threshold=critical
+          snyk test --all-projects --detection-depth=4 --exclude=docker,Dockerfile,test-apps/* --severity-threshold=critical
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_API_TOKEN }}


### PR DESCRIPTION
Excluding test apps from snyk. These are only used for example and testing purposes. 

The snyk scans have been failing due to some react-script in the test apps. I don't think this is important to highlight.