### PR TITLE
feat: added support for nyc configuration throw environment variables

### DIFF
--- a/task-utils.js
+++ b/task-utils.js
@@ -72,8 +72,21 @@ function readNycOptions(workingDirectory) {
     }
   }
 
+  let nycConfigEnvVariables = {}
+  if (process.env.NYC_CONFIG) {
+    try {
+      nycConfigEnvVariables = JSON.parse(process.env.NYC_CONFIG)
+      if (nycConfigEnvVariables === null || typeof nycConfigEnvVariables !== 'object') {
+        throw new Error('NYC_CONFIG environment configuration is set, but it is not an object as expected')
+      }
+    } catch (error) {
+      throw new Error(`Failed to load environment NYC_CONFIG: ${error.message}`)
+    }
+  }
+
   const nycOptions = combineNycOptions(
     defaultNycOptions,
+    nycConfigEnvVariables,
     nycrc,
     nycrcJson,
     nycrcYaml,
@@ -82,6 +95,7 @@ function readNycOptions(workingDirectory) {
     nycConfigCommonJs,
     pkgNycOptions
   )
+
   debug('combined NYC options %o', nycOptions)
 
   return nycOptions


### PR DESCRIPTION
This PR introduces the ability to configure nyc through environment variables, requiring the maintenance of one less configuration file.

Such as:
`NYC_CONFIG="{\"report-dir\":\"coverage/cypress\",\"temp-dir\":\"coverage/temp\"}" npm run your:testing:task`