### PR TITLE
fix: Check for inputSourceMap existing before regex execution

### DIFF
--- a/support-utils.js
+++ b/support-utils.js
@@ -137,8 +137,9 @@ const filterSupportFilesFromCoverage = (
 function fixSourcePaths(coverage) {
   Object.values(coverage).forEach((file) => {
     const { path: absolutePath, inputSourceMap } = file
+    if (!absolutePath) return
     const fileName = /([^\/\\]+)$/.exec(absolutePath)[1]
-    if (!inputSourceMap || !fileName) return
+    if (!fileName) return
 
     if (inputSourceMap.sourceRoot) inputSourceMap.sourceRoot = ''
     inputSourceMap.sources = inputSourceMap.sources.map((source) =>

--- a/support-utils.js
+++ b/support-utils.js
@@ -137,7 +137,7 @@ const filterSupportFilesFromCoverage = (
 function fixSourcePaths(coverage) {
   Object.values(coverage).forEach((file) => {
     const { path: absolutePath, inputSourceMap } = file
-    if (!absolutePath) return
+    if (!inputSourceMap) return
     const fileName = /([^\/\\]+)$/.exec(absolutePath)[1]
     if (!fileName) return
 


### PR DESCRIPTION
Optimize for fewer regex executions. I'm actually wondering if the regex is even necessary.