### PR TITLE
fix: add `exports` to `package.json` for Node.JS v20.19.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "@cypress/code-coverage",
   "version": "0.0.0-development",
   "description": "Saves the code coverage collected during Cypress tests",
-  "main": "index.js",
   "scripts": {
     "start": "parcel serve cypress/index.html",
     "coverage:verify": "npx nyc report --check-coverage true --lines 80",
@@ -23,6 +22,24 @@
     "babel-loader": "^8.3 || ^9",
     "cypress": "*",
     "webpack": "^4 || ^5"
+  },
+  "exports": {
+    "./common-utils": "./common-utils.js",
+    "./cypress-config": "./cypress-config.js",
+    "./middleware/express": "./middleware/express.js",
+    "./middleware/hapi": "./middleware/hapi.js",
+    "./middleware/nextjs": "./middleware/nextjs.js",
+    "./package.json": "./package.json",
+    "./plugins": "./plugins.js",
+    "./support-utils": "./support-utils.js",
+    "./support": "./support.js",
+    "./task-utils": "./task-utils.js",
+    "./task": {
+      "types": "./task.d.ts",
+      "default": "./task.js"
+    },
+    "./use-babelrc": "./use-babelrc.js",
+    "./*.js": "./*.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Add Node.JS export conditions to `package.json`, so that the examples of things like `import '@cypress/code-coverage/support'` continue to work in Node.JS v20.19.0.

I've added `package.json` too since it's theoretically possible somebody did `require("@cypress/code-coverage/package.json")`, so we should support that too.

See: https://nodejs.org/api/packages.html#exports

### The bug this fixes

I'm not sure why, but `import "@cypress/code-coverage/task"` in a `cypress.config.ts` file seems to break in Node.JS v20.19.0, despite working before, with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './task' is not defined by "exports" in /node_modules/@cypress/code-coverage/package.json imported from /cypress.config.js
```

I think this is probably a bug in `ts-node/esm`, since it looks like there's a similar issue with `@swc-node/register/esm-register`: https://github.com/nodejs/node/issues/57536

Still, it's worth changing this package so that `import '@cypress/code-coverage/support'` works in ESM too!