### PR TITLE
Allow babel-loader v10 as peer-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "peerDependencies": {
     "@babel/core": "^7.0.1",
     "@babel/preset-env": "^7.0.0",
-    "babel-loader": "^8.3 || ^9",
+    "babel-loader": "^8.3 || ^9 || ^10",
     "cypress": "*",
     "webpack": "^4 || ^5"
   },


### PR DESCRIPTION
- Closes https://github.com/cypress-io/code-coverage/issues/938

This was changed in webpack-preprocessor: https://github.com/cypress-io/cypress/pull/31218 and should be reflected here as well.