### PR TITLE
enh: allow to only save coverage map

### DIFF
--- a/task.js
+++ b/task.js
@@ -65,7 +65,7 @@ let coverageMap = (() => {
   return istanbul.createCoverageMap(previousCoverage)
 })()
 
-function saveCoverage(coverage) {
+function saveCoverage(coverage = coverageMap) {
   if (!existsSync(nycReportOptions.tempDir)) {
     mkdirSync(nycReportOptions.tempDir, { recursive: true })
     debug('created folder %s for output coverage', nycReportOptions.tempDir)


### PR DESCRIPTION
The coverageReport task saves the result in the out.json and generates a report in the coverage folder. But sometimes, the user does not want to generate the report (parallel tests for instance). This PR allows to override the coverageReport task by just calling the saveCoverage without the coverageMap parameter.