### PR TITLE
fix: support NYC cwd option for file pattern matching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ workflows:
             - lint
             - test-code-coverage-plugin
             - test-all-files
+            - test-all-files-cwd
             - test-backend
             - test-batch-send-coverage
             - test-before-all-visit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,6 +145,7 @@ workflows:
             parameters:
               jobname:
                 - all-files
+                - all-files-cwd
                 - backend
                 - batch-send-coverage
                 - before-all-visit

--- a/task-utils.js
+++ b/task-utils.js
@@ -293,6 +293,7 @@ function tryFindingLocalFiles(nycFilename) {
 function findSourceFiles(nycOptions) {
   debug('include all files options: %o', {
     all: nycOptions.all,
+    cwd: nycOptions.cwd,
     include: nycOptions.include,
     exclude: nycOptions.exclude,
     extension: nycOptions.extension
@@ -330,7 +331,12 @@ function findSourceFiles(nycOptions) {
 
   debug('searching files to include using patterns %o', patterns)
 
-  const allFiles = globby.sync(patterns, { absolute: true })
+  const globbyOptions = { absolute: true }
+  if (nycOptions.cwd) {
+    globbyOptions.cwd = nycOptions.cwd
+  }
+  const allFiles = globby.sync(patterns, globbyOptions)
+  
   return allFiles
 }
 /**

--- a/task-utils.js
+++ b/task-utils.js
@@ -336,7 +336,7 @@ function findSourceFiles(nycOptions) {
     globbyOptions.cwd = nycOptions.cwd
   }
   const allFiles = globby.sync(patterns, globbyOptions)
-  
+
   return allFiles
 }
 /**

--- a/test-apps/all-files-cwd/.babelrc
+++ b/test-apps/all-files-cwd/.babelrc
@@ -1,0 +1,3 @@
+{
+  "plugins": ["istanbul"]
+}

--- a/test-apps/all-files-cwd/README.md
+++ b/test-apps/all-files-cwd/README.md
@@ -1,0 +1,1 @@
+# example: all files

--- a/test-apps/all-files-cwd/cypress.config.js
+++ b/test-apps/all-files-cwd/cypress.config.js
@@ -1,0 +1,11 @@
+const { defineConfig } = require('cypress')
+
+module.exports = defineConfig({
+  fixturesFolder: false,
+  e2e: {
+    setupNodeEvents(on, config) {
+      return require('./cypress/plugins/index.js')(on, config)
+    },
+    baseUrl: 'http://localhost:1234'
+  }
+})

--- a/test-apps/all-files-cwd/cypress/e2e/spec.cy.js
+++ b/test-apps/all-files-cwd/cypress/e2e/spec.cy.js
@@ -1,0 +1,12 @@
+/// <reference types="cypress" />
+it('works', () => {
+  cy.visit('/')
+  cy.contains('Page body')
+
+  cy.window()
+    .invoke('reverse', 'super')
+    .should('equal', 'repus')
+
+  // application's code should be instrumented
+  cy.window().should('have.property', '__coverage__')
+})

--- a/test-apps/all-files-cwd/cypress/plugins/index.js
+++ b/test-apps/all-files-cwd/cypress/plugins/index.js
@@ -1,0 +1,4 @@
+module.exports = (on, config) => {
+  require('@cypress/code-coverage/task')(on, config)
+  return config
+}

--- a/test-apps/all-files-cwd/cypress/support/commands.js
+++ b/test-apps/all-files-cwd/cypress/support/commands.js
@@ -1,0 +1,1 @@
+import '@cypress/code-coverage/support'

--- a/test-apps/all-files-cwd/cypress/support/e2e.js
+++ b/test-apps/all-files-cwd/cypress/support/e2e.js
@@ -1,0 +1,1 @@
+require('./commands')

--- a/test-apps/all-files-cwd/index.html
+++ b/test-apps/all-files-cwd/index.html
@@ -1,0 +1,17 @@
+<body>
+  Page body
+  <script src="main.js"></script>
+  <script src="second.js"></script>
+  <script>
+    // use functions creates in "main.js"
+    if (add(2, 3) !== 5) {
+      throw new Error('wrong addition')
+    }
+    if (sub(2, 3) !== -1) {
+      throw new Error('wrong subtraction')
+    }
+    if (reverse('foo') !== 'oof') {
+      throw new Error('wrong string reverse')
+    }
+  </script>
+</body>

--- a/test-apps/all-files-cwd/main.js
+++ b/test-apps/all-files-cwd/main.js
@@ -1,0 +1,3 @@
+window.add = (a, b) => a + b
+
+window.sub = (a, b) => a - b

--- a/test-apps/all-files-cwd/package.json
+++ b/test-apps/all-files-cwd/package.json
@@ -14,8 +14,6 @@
   "nyc": {
     "all": true,
     "cwd": "../all-files",
-    "temp-dir": ".nyc_output",
-    "report-dir": "cypress-coverage",
     "include": "*.js"
   },
   "devDependencies": {

--- a/test-apps/all-files-cwd/package.json
+++ b/test-apps/all-files-cwd/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "example-all-files-cwd",
+  "description": "Report all files cwd",
+  "private": true,
+  "scripts": {
+    "cy:run": "cypress run",
+    "start": "parcel serve index.html",
+    "start:windows": "npx bin-up parcel serve index.html",
+    "pretest": "rimraf .nyc_output .cache coverage dist",
+    "test": "start-test 1234 cy:run",
+    "coverage:verify": "npx nyc report --check-coverage true --lines 100",
+    "coverage:check-files": "check-coverage main.js && check-coverage second.js && check-coverage not-covered.js && check-coverage cypress.config.js && only-covered --from coverage/coverage-final.json main.js second.js not-covered.js cypress.config.js"
+  },
+  "nyc": {
+    "all": true,
+    "cwd": "../all-files",
+    "include": "*.js"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.22.15"
+  }
+}

--- a/test-apps/all-files-cwd/package.json
+++ b/test-apps/all-files-cwd/package.json
@@ -14,6 +14,8 @@
   "nyc": {
     "all": true,
     "cwd": "../all-files",
+    "temp-dir": ".nyc_output",
+    "report-dir": "cypress-coverage",
     "include": "*.js"
   },
   "devDependencies": {

--- a/test-apps/all-files-cwd/package.json
+++ b/test-apps/all-files-cwd/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "cy:run": "cypress run",
-    "start": "parcel serve index.html",
-    "start:windows": "npx bin-up parcel serve index.html",
+    "start": "parcel serve ../all-files/index.html",
+    "start:windows": "npx bin-up parcel serve ../all-files/index.html",
     "pretest": "rimraf .nyc_output .cache coverage dist",
     "test": "start-test 1234 cy:run",
     "coverage:verify": "npx nyc report --check-coverage true --lines 100",

--- a/test-apps/all-files-cwd/package.json
+++ b/test-apps/all-files-cwd/package.json
@@ -8,7 +8,7 @@
     "start:windows": "npx bin-up parcel serve ../all-files/index.html",
     "pretest": "rimraf .nyc_output .cache coverage dist",
     "test": "start-test 1234 cy:run",
-    "coverage:verify": "npx nyc report --check-coverage true --lines 100",
+    "coverage:verify": "npx nyc report --temp-dir ../all-files-cwd/.nyc_output --check-coverage true --lines 100",
     "coverage:check-files": "check-coverage main.js && check-coverage second.js && check-coverage not-covered.js && check-coverage cypress.config.js && only-covered --from coverage/coverage-final.json main.js second.js not-covered.js cypress.config.js"
   },
   "nyc": {

--- a/test-apps/all-files-cwd/second.js
+++ b/test-apps/all-files-cwd/second.js
@@ -1,0 +1,7 @@
+// this file should be excluded from the final coverage numbers
+// using "nyc.exclude" list in package.json
+window.reverse = s =>
+  s
+    .split('')
+    .reverse()
+    .join('')


### PR DESCRIPTION
- Add support for NYC 'cwd' option in findSourceFiles function
- Pass cwd option to globby for proper file pattern resolution
- Add test case 'all-files-cwd' to verify cwd functionality
- Update CI configuration to include new test case in matrix

This fix ensures that when NYC is configured with a 'cwd' option, the file patterns are resolved relative to the specified directory instead of the current working directory.