### PR TITLE
chore: use npm credentials context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,7 @@ workflows:
                 - redirect
       - windows_test
       - publish:
+          context: org-npm-credentials
           filters:
             branches:
               only:


### PR DESCRIPTION
uses new npm context to more easily adhere to token rotation 