### PR TITLE
chore: add minimum release age and vulnerability alerts to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,11 +6,22 @@
   "major": {
     "automerge": false
   },
+  "minimumReleaseAge": "7 days",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "prHourlyLimit": 2,
   "updateNotScheduled": false,
   "timezone": "America/New_York",
   "schedule": [
     "every weekend"
   ],
-  "masterIssue": true
+  "masterIssue": true,
+  "packageRules": [
+    {
+      "matchPackageNames": ["cypress"],
+      "minimumReleaseAge": "0 days"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary
- Add a 7-day `minimumReleaseAge` for all dependencies to avoid pulling in potentially unstable new releases
- Exempt the `cypress` package from this cooldown so updates are available immediately
- Enable `osvVulnerabilityAlerts` for OSV vulnerability scanning
- Add `vulnerabilityAlerts` config to bypass the 7-day cooldown for security fixes


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only Renovate bot configuration changes; no application runtime or security logic in the repo is modified.
> 
> **Overview**
> Renovate is configured to **wait 7 days** after a dependency release before opening update PRs, reducing churn from brand-new publishes.
> 
> **Security and exceptions:** `osvVulnerabilityAlerts` is enabled, and `vulnerabilityAlerts` sets `minimumReleaseAge` to **0 days** so security fixes are not delayed. A `packageRules` entry sets **0 days** for the `cypress` package so Cypress updates are not held back.
> 
> A trailing comma was added after `masterIssue` for valid JSON before the new `packageRules` block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 586a8db7ca2c664a23bf7f8972204b35f5b53765. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->