### PR TITLE
chore: fix 'besta' typo in semantic-release prerelease branch name

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -3,7 +3,7 @@
     "master",
     "next",
     {
-      "name": "besta",
+      "name": "beta",
       "prerelease": true
     },
     {


### PR DESCRIPTION
## Summary

Fixes a `besta` → `beta` typo in `.releaserc`, found during a security review of this repo's CI configuration.

The CircleCI `publish` job filter allows the `beta` branch, but semantic-release was configured for `besta`, so a beta prerelease could never actually publish: the publish job only runs on `beta`, where semantic-release rejects the unconfigured branch.

## Review notes

- Neither `beta` nor `besta` currently exists on the remote, so this is a dormant-config fix with no behavior change today.
- `.releaserc` was last touched in 2022.
- The commit is `chore:` typed, so merging does not trigger a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)