### PR TITLE
chore: allow babel@8 peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "node": ">=20"
   },
   "peerDependencies": {
-    "@babel/core": "^7.0.1",
-    "@babel/preset-env": "^7.0.0",
+    "@babel/core": "^7.0.1 || ^8",
+    "@babel/preset-env": "^7.0.0 || ^8",
     "babel-loader": "^8.3 || ^9 || ^10",
     "cypress": ">=15.10.0",
     "webpack": "^4 || ^5"


### PR DESCRIPTION
This PR allow the babel@8 peer dependencies for `@babel/core` and `@babel/preset-env`.

Cause: while trying to use this package with the latest version of `@vitejs/plugin-react`, npm throws the following errors:

```
ERESOLVE could not resolve
...
peer @babel/preset-env@"^7.0.0" from @cypress/code-coverage@4.0.3
...
dev @vitejs/plugin-react@"*" from the root project
Conflicting peer dependency: @babel/core@8.0.1
```